### PR TITLE
RDMPE-16 Turn off enforceFocus

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aha-app/react-bootstrap-modal",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "",
   "author": {
     "name": "Jason Quense",

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -207,6 +207,7 @@ class Modal extends React.Component {
         transition={transition}
         dialogTransitionTimeout={Modal.TRANSITION_DURATION}
         backdropTransitionTimeout={Modal.BACKDROP_TRANSITION_DURATION}
+        enforceFocus={false}
       >
         {modal}
       </BaseModal>


### PR DESCRIPTION
Right now, the react-bootstrap-modal code we use runs into issues with
selectro. Selectro relies on observing and changing user focus to
function. However, the react-bootstrap-modal code uses a  react-overlay
that has an `enforceFocus` option turned on by default, which causes the
modal to grab back focus if it is ever lost. This leads to focus
contention between the modal and selectro, preventing the selectro from
being searchable, and also causing the selectro component to constantly
re-fetch records.

[Aha! feature](https://big.aha.io/features/RDMPE-16)